### PR TITLE
Make necessary updates to bump chebfun to 0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "chebfun" %}
-{% set version = "0.5.0" %}
+{% set version = "0.10.0" %}
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,31 +8,32 @@ package:
 
 source:
   url: https://github.com/chebpy/chebpy/archive/v{{ version }}.tar.gz
-  sha256: c0a92e72adbcc2d4ac7d05de435978f87f36563ab82fafbe80e14272a636ca6e
+  sha256: b7a066c06d26825cb1031ed7394026ccfa6d98e417710fe16bdd9ee3e6644132
 
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.7
+    - python {{ python_min }}
     - pip
+    - hatchling
   run:
-    - python >=3.7
-    - numpy >=1.16
-    - pyfftw >=0.11
+    - python >={{ python_min }}
+    - numpy >=2.4.1
+    - matplotlib-base >=3.10.0
 
 test:
   requires:
-    - nose
+    - python {{ python_min }}
+    - pip
   imports:
     - chebpy
-  source_files:
-    - tests/
   commands:
-    - nosetests --where=tests/
+    - pip check
+    - python -c "import importlib.metadata; assert importlib.metadata.version('chebfun') == '{{ version }}'"
 
 about:
   home: https://github.com/chebpy/chebpy


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Updates `chebfun` to `0.10.0` and refreshes the recipe for the current upstream packaging metadata.

Relevant recipe updates:
* add `hatchling` as the PEP 517 build backend
* set the Python floor to `3.11`
* update runtime dependencies to `numpy >=2.4.1` and `matplotlib-base >=3.10.0`
* remove stale `pyfftw` and `nose` usage
* use `pip install --no-deps --no-build-isolation`

Local checks performed:
* verified the `v0.10.0` source archive sha256
* built the upstream wheel from the `v0.10.0` source archive with `build` and `hatchling`
* rendered and parsed the Jinja recipe locally

I could not run a full local conda build because `conda-build`, `rattler-build`, and `conda-smithy` are not installed in my local checkout.